### PR TITLE
Skip uninstalls

### DIFF
--- a/script/setup.js
+++ b/script/setup.js
@@ -359,7 +359,7 @@ try {
 
 	if (skipUninstalls) {
 		console.log();
-		console.log(chalk.gray`Skipping removal of setup script.`);
+		console.log(chalk.gray`➖ Skipping removal of setup script.`);
 	} else {
 		console.log();
 		console.log(chalk.gray`Removing setup script...`);

--- a/script/setup.js
+++ b/script/setup.js
@@ -33,6 +33,7 @@ try {
 			repository: { type: "string" },
 			title: { type: "string" },
 			"skip-api": { type: "boolean" },
+			"skip-uninstalls": { type: "boolean" },
 		},
 		tokens: true,
 		strict: false,
@@ -365,19 +366,41 @@ try {
 	console.log(chalk.red(error.stack));
 	caughtError = error;
 } finally {
-	console.log();
-	console.log(
-		chalk.gray`Removing devDependency packages only used for setup...`
-	);
+	const { values } = parseArgs({
+		args: process.argv.slice(2),
+		options: {
+			description: { type: "string" },
+			owner: { type: "string" },
+			repository: { type: "string" },
+			title: { type: "string" },
+			"skip-api": { type: "boolean" },
+			"skip-uninstalls": { type: "boolean" },
+		},
+		tokens: true,
+		strict: false,
+	});
 
-	try {
-		await $`pnpm remove execa @clack/prompts all-contributors-cli chalk octokit npm-user replace-in-file title-case -D`;
-	} catch (error) {
-		console.log("Error uninstalling packages:", error);
-		caughtError = error;
+	const skipUninstalls = values["skip-uninstalls"];
+
+	if (skipUninstalls) {
+		console.log(
+			chalk.gray`➖ Skipping removal of devDependencies only used for setup.`
+		);
+	} else {
+		console.log();
+		console.log(
+			chalk.gray`Removing devDependency packages only used for setup...`
+		);
+
+		try {
+			await $`pnpm remove execa @clack/prompts all-contributors-cli chalk octokit npm-user replace-in-file title-case -D`;
+		} catch (error) {
+			console.log("Error uninstalling packages:", error);
+			caughtError = error;
+		}
+
+		console.log(chalk.gray`✔️ Done.`);
 	}
-
-	console.log(chalk.gray`✔️ Done.`);
 }
 
 console.log();

--- a/script/setup.js
+++ b/script/setup.js
@@ -355,13 +355,20 @@ try {
 		console.log(chalk.gray`✔️ Done.`);
 	}
 
-	console.log();
-	console.log(chalk.gray`Removing setup script...`);
+	const skipUninstalls = values["skip-uninstalls"];
 
-	await fs.rm("./script", { force: true, recursive: true });
-	await fs.rm(".github/workflows/setup.yml");
+	if (skipUninstalls) {
+		console.log();
+		console.log(chalk.gray`Skipping removal of setup script.`);
+	} else {
+		console.log();
+		console.log(chalk.gray`Removing setup script...`);
 
-	console.log(chalk.gray`✔️ Done.`);
+		await fs.rm("./script", { force: true, recursive: true });
+		await fs.rm(".github/workflows/setup.yml");
+
+		console.log(chalk.gray`✔️ Done.`);
+	}
 } catch (error) {
 	console.log(chalk.red(error.stack));
 	caughtError = error;


### PR DESCRIPTION

- [x] Addresses an existing open issue: fixes #352
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/template-typescript-node-package/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/template-typescript-node-package/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
adds skip-uninstalls on line 36 and parses args again in the ```finally``` block and skips uninstall of devDeps only used in setup
```
	const { values } = parseArgs({
		args: process.argv.slice(2),
		options: {
			description: { type: "string" },
			owner: { type: "string" },
			repository: { type: "string" },
			title: { type: "string" },
			"skip-api": { type: "boolean" },
			"skip-uninstalls": { type: "boolean" },
		},
		tokens: true,
		strict: false,
	});
const skipUninstalls = values["skip-uninstalls"];

	if (skipUninstalls) {
		console.log(
			chalk.gray`➖ Skipping removal of devDependencies only used for setup.`
		);
	} else {
		console.log();
		console.log(
			chalk.gray`Removing devDependency packages only used for setup...`
		);

		try {
			await $`pnpm remove execa @clack/prompts all-contributors-cli chalk octokit npm-user replace-in-file title-case -D`;
		} catch (error) {
			console.log("Error uninstalling packages:", error);
			caughtError = error;
		}

		console.log(chalk.gray`✔️ Done.`);
	}
```
also skips removal of ```./script```
```
	const skipUninstalls = values["skip-uninstalls"];

	if (skipUninstalls) {
		console.log();
		console.log(chalk.gray`➖ Skipping removal of setup script.`);
	} else {
		console.log();
		console.log(chalk.gray`Removing setup script...`);

		await fs.rm("./script", { force: true, recursive: true });
		await fs.rm(".github/workflows/setup.yml");

		console.log(chalk.gray`✔️ Done.`);
	}
```
